### PR TITLE
Add bundle.js explicitly to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dependency-reduced-pom.xml
 *.iml
 .log
 /src/main/resources/static/built
+/src/main/resources/static/built/bundle.js
+/src/main/resources/static/built/bundle.js.map


### PR DESCRIPTION
* Fix merge conflict issue caused by built folder in gitignore not
facilitating gitignore of the contents - bundle.js and bundle.js.map
